### PR TITLE
fix dpkg-gencontrol: warning: ${shlibs:Depends}

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 3.9.8
 
 Package: deepin-qt5config
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, deepin-desktop-base
+Depends: ${misc:Depends}, deepin-desktop-base
 Description: Configure Qt feature on deepin platform
 	load(deepin_qt) in *.pro file.


### PR DESCRIPTION
 This related to "unknown substitution variable ${shlibs:Depends}"
On dpkg-buildpackage process